### PR TITLE
[FIX] Fixes failing schema creation due to unsupported nullable-property of ORM\ManyToOne annotation

### DIFF
--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -66,7 +66,7 @@ class Order implements PspOrderInterface
      * @var account
      *
      * One Order has One Account.
-     * @ORM\ManyToOne(targetEntity="TechDivision\PspMock\Entity\Account", cascade={"persist"}, nullable=true)
+     * @ORM\ManyToOne(targetEntity="TechDivision\PspMock\Entity\Account", cascade={"persist"})
      */
     private $account;
 


### PR DESCRIPTION
As documented by Doctrine, the `ORM\ManyToOne` annotation does not support the `nullable` property, thus generating the schema (`doctrine:schema:create`) would fail, tearing subsequent steps with it.